### PR TITLE
Docs: Update for textual-slidecontainer

### DIFF
--- a/docs/textual-slidecontainer/index.md
+++ b/docs/textual-slidecontainer/index.md
@@ -1,7 +1,11 @@
-<picture>
+<picture class="only-github">
   <source media="(prefers-color-scheme: dark)" srcset="https://edward-jazzhands.github.io/assets/textual-slidecontainer/banner-dark-theme.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://edward-jazzhands.github.io/assets/textual-slidecontainer/banner-light-theme.png">  
   <img src="https://edward-jazzhands.github.io/assets/textual-slidecontainer/banner-light-theme.png">
 </picture>
+
+![banner](https://edward-jazzhands.github.io/assets/textual-slidecontainer/banner-light-theme.png#only-light)
+![banner](https://edward-jazzhands.github.io/assets/textual-slidecontainer/banner-dark-theme.png#only-dark)
 
 # textual-slidecontainer
 


### PR DESCRIPTION
Automated documentation update from the `textual-slidecontainer` repository.

Triggered by commit: `e20d18c87bf75978bdb517c581db910346ba0dea`