### PR TITLE
Docs: Update for textual-slidecontainer

### DIFF
--- a/docs/textual-slidecontainer/docs.md
+++ b/docs/textual-slidecontainer/docs.md
@@ -1,5 +1,10 @@
 # Textual-SlideContainer<br>Documentation and Guide
 
+## Requirements
+
+- Python >= 3.9
+- [Textual](https://textual.textualize.io/) >= 3.71
+
 ## Installation
 
 ```sh

--- a/docs/textual-slidecontainer/index.md
+++ b/docs/textual-slidecontainer/index.md
@@ -9,12 +9,11 @@
 
 # textual-slidecontainer
 
-[![badge](https://img.shields.io/badge/linted-Ruff-blue?style=for-the-badge&logo=ruff)](https://astral.sh/ruff)
-[![badge](https://img.shields.io/badge/formatted-black-black?style=for-the-badge)](https://github.com/psf/black)
-[![badge](https://img.shields.io/badge/type_checked-MyPy_(strict)-blue?style=for-the-badge&logo=python)](https://mypy-lang.org/)
-[![badge](https://img.shields.io/badge/Type_checked-Pyright_(strict)-blue?style=for-the-badge&logo=python)](https://microsoft.github.io/pyright/)
-[![badge](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](https://opensource.org/license/mit)
-[![badge](https://img.shields.io/badge/framework-Textual-blue?style=for-the-badge)](https://textual.textualize.io/)
+[![badge](https://img.shields.io/pypi/v/textual-slidecontainer)](https://pypi.org/project/textual-slidecontainer/)
+[![badge](https://img.shields.io/github/v/release/edward-jazzhands/textual-slidecontainer)](https://github.com/edward-jazzhands/textual-slidecontainer/releases/latest)
+[![badge](https://img.shields.io/badge/Requires_Python->=3.9-blue&logo=python)](https://python.org)
+[![badge](https://img.shields.io/badge/Strictly_Typed-MyPy_&_Pyright-blue&logo=python)](https://mypy-lang.org/)
+[![badge](https://img.shields.io/badge/license-MIT-blue)](https://opensource.org/license/mit)
 
 This is a library that provides a custom container (widget) called the SlideContainer.
 


### PR DESCRIPTION
Automated documentation update from the `textual-slidecontainer` repository.

Triggered by commit: `be19f5c1cc0fceb0feb21e50e05d844a37b8e00a`